### PR TITLE
Add workaround for https://rt.cpan.org/Public/Bug/Display.html?id=124514

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,14 @@ RUN apk update \
              perl-dev \
              make \
              git \
-             wget \
-             \
-  && wget https://cpanmin.us/ -O /bin/cpanm \
-  && chmod +x /bin/cpanm \
-  && cpanm Parse::Win32Registry \
   && rm -rf /var/cache/apk/*
+
+RUN git clone https://github.com/gitpan/Parse-Win32Registry.git /opt/win32registry \
+&& cd /opt/win32registry \
+# Fix bug 124514 https://rt.cpan.org/Public/Bug/Display.html?id=124514
+&& sed -i "s/my \$epoch_offset = timegm(0, 0, 0, 1, 0, 70);/my \$epoch_offset = timegm(0, 0, 0, 1, 0, 1970);/" /opt/win32registry/lib/Parse/Win32Registry/Base.pm \
+&& sed -i "s/my \$epoch_offset = timegm(0, 0, 0, 1, 0, 70);/my \$epoch_offset = timegm(0, 0, 0, 1, 0, 1970);/" /opt/win32registry/t/misc.t \
+&& perl Makefile.PL && make && make test && make install
 
 RUN adduser -D regripper \
   && git clone --branch=master \


### PR DESCRIPTION
Hi,

when I tried to build the container I received this error:

```
# docker build -t regripper:latest .
Sending build context to Docker daemon  63.49kB
Step 1/9 : FROM alpine
 ---> e7d92cdc71fe
Step 2/9 : LABEL maintainer "ilya@ilyaglotov.com"
 ---> Using cache
 ---> 6d7da496b360
Step 3/9 : ENV PERL5LIB /regripper
 ---> Using cache
 ---> 200e811b7594
Step 4/9 : RUN apk update   && apk add perl   && apk add --virtual .temp              perl-dev              make              git              wget                && wget https://cpanmin.us/ -O /bin/cpanm   && chmod +x /bin/cpanm   && cpanm Parse::Win32Registry   && rm -rf /var/cache/apk/*
 ---> Running in bcffc62047a7
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
v3.11.3-126-gca6e5756c3 [http://dl-cdn.alpinelinux.org/alpine/v3.11/main]
v3.11.3-127-g6253a98c55 [http://dl-cdn.alpinelinux.org/alpine/v3.11/community]
OK: 11268 distinct packages available
(1/2) Installing libbz2 (1.0.8-r1)
(2/2) Installing perl (5.30.1-r0)
Executing busybox-1.31.1-r9.trigger
OK: 42 MiB in 16 packages
(1/14) Installing perl-utils (5.30.1-r0)
(2/14) Installing perl-dev (5.30.1-r0)
(3/14) Installing make (4.2.1-r2)
(4/14) Installing ca-certificates (20191127-r1)
(5/14) Installing nghttp2-libs (1.40.0-r0)
(6/14) Installing libcurl (7.67.0-r0)
(7/14) Installing expat (2.2.9-r1)
(8/14) Installing pcre2 (10.34-r1)
(9/14) Installing git (2.24.1-r0)
(10/14) Installing perl-error (0.17028-r0)
(11/14) Installing perl-git (2.24.1-r0)
(12/14) Installing git-perl (2.24.1-r0)
(13/14) Installing wget (1.20.3-r0)
(14/14) Installing .temp (20200314.193818)
Executing busybox-1.31.1-r9.trigger
Executing ca-certificates-20191127-r1.trigger
OK: 67 MiB in 30 packages
--2020-03-14 19:38:54--  https://cpanmin.us/
Resolving cpanmin.us... 151.101.194.217, 151.101.66.217, 151.101.2.217, ...
Connecting to cpanmin.us|151.101.194.217|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 302780 (296K) [text/plain]
Saving to: '/bin/cpanm'

	 0K .......... .......... .......... .......... .......... 16%  860K 0s
	50K .......... .......... .......... .......... .......... 33% 2.18M 0s
   100K .......... .......... .......... .......... .......... 50% 5.33M 0s
   150K .......... .......... .......... .......... .......... 67% 6.76M 0s
   200K .......... .......... .......... .......... .......... 84% 4.03M 0s
   250K .......... .......... .......... .......... .....     100% 10.2M=0.1s

2020-03-14 19:38:54 (2.55 MB/s) - '/bin/cpanm' saved [302780/302780]

--> Working on Parse::Win32Registry
Fetching http://www.cpan.org/authors/id/J/JM/JMACFARLA/Parse-Win32Registry-1.0.tar.gz ... OK
Configuring Parse-Win32Registry-1.0 ... OK
Building and testing Parse-Win32Registry-1.0 ... ! Installing Parse::Win32Registry failed. See /root/.cpanm/work/1584214734.18/build.log for details. Retry with --force to force install it.
FAIL
The command '/bin/sh -c apk update   && apk add perl   && apk add --virtual .temp              perl-dev              make              git              wget                && wget https://cpanmin.us/ -O /bin/cpanm   && chmod +x /bin/cpanm   && cpanm Parse::Win32Registry   && rm -rf /var/cache/apk/*' returned a non-zero code: 1
```

There is a bug [#124514](https://rt.cpan.org/Public/Bug/Display.html?id=124514) in Parse::Win32Registry. Thanks to the bugreporter the fix is fairly easy. But unfortunately not yet commited/merged to the builds.

I switched to manually installing Parse::Win32Registry and fixing the bug first. So this works for me now. I admit I have not tested it thoroughly but all tested commands/regripper-plugins work.

So perhaps you are interested in my solution.